### PR TITLE
Added -integrated-as for vanilla mips build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ CFLAGS+=-msoft-float
 CFLAGS+=-DDUK_USE_PACKED_TVAL=1
 CFLAGS+=--sysroot=$(MIPS_SDK)/sysroot
 CFLAGS+=-I/usr/include/edit
+CFLAGS+=-integrated-as
 LDFLAGS+=--sysroot=$(MIPS_SDK)/sysroot
 LDFLAGS+=-B $(MIPS_SDK)/bin
 LDFLAGS+=-static


### PR DESCRIPTION
After testing the newly merged commit on jenkins, it looks like building both with the jenkins cheri128 and cheri256 sdks happily just work, but jenkins mips sdk wants a -integrated-as flag to work.